### PR TITLE
Explains checks allowed on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This module was inspired by [Test::Deep::JSON](https://metacpan.org/pod/Test::De
 
         is '{"a":1}', json({a => 1});
 
+        is '{"a":{"b":1},"c":2}', json hash { field a => {b => 1}; etc; };
+
 - $check = relaxed\_json($expected)
 
     Verify the value in the `$got` relaxed JSON string has the same data structure as `$expected`.

--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,6 @@
 requires 'JSON::MaybeXS';
-requires 'Test2', '1.302160';
-requires 'Test2::Suite', '0.000122';
+requires 'Test2', '1.302199';
+requires 'Test2::Suite', '0.000163';
 
 on 'test' => sub {
     requires 'Test2::V0';

--- a/lib/Test2/Tools/JSON.pm
+++ b/lib/Test2/Tools/JSON.pm
@@ -75,6 +75,8 @@ Verify the value in the C<$got> JSON string has the same data structure as C<$ex
 
     is '{"a":1}', json({a => 1});
 
+    is '{"a":{"b":1},"c":2}', json hash { field a => {b => 1}; etc; };
+
 =item $check = relaxed_json($expected)
 
 Verify the value in the C<$got> relaxed JSON string has the same data structure as C<$expected>.

--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -3,20 +3,45 @@ use Test2::Tools::JSON;
 
 use Test2::Compare::Custom;
 
-is {
-    foo  => 'bar',
-    json => '{"a":1}',
-}, {
-    foo  => 'bar',
-    json => json({ a => E }),
+subtest 'JSON cmp success' => sub {
+    is {
+        foo  => 'bar',
+        json => '{"a":1}',
+    }, {
+        foo  => 'bar',
+        json => json({ a => E }),
+    };
 };
 
-is {
-    foo  => 'bar',
-    json => '{"a":1}',
-}, hash {
-    field json => json({ a => 1 });
-    etc;
+subtest 'JSON in JSON cmp success (compare by Test2::Tools::Compare subs)' => sub {
+    is {
+        foo  => 'bar',
+        json => '{"a":10,"b":{"b1":20},"c":"[30,\"foo\"]"}',
+    }, {
+        foo  => 'bar',
+        json => json hash {
+            field b => hash {
+                field b1 => number 20;
+                end;
+            };
+            field c => json array {
+                item 0 => number 30;
+                item 1 => string "foo";
+                end;
+            };
+            etc;
+        },
+    };
+};
+
+subtest 'JSON cmp success (exact hash)' => sub {
+    is {
+        foo  => 'bar',
+        json => '{"a":1}',
+    }, hash {
+        field json => json({ a => 1 });
+        etc;
+    };
 };
 
 subtest 'JSON cmp failure (expect raw hash)' => sub {
@@ -33,7 +58,7 @@ subtest 'JSON cmp failure (expect raw hash)' => sub {
                 table => {
                     header => [qw/PATH LNs GOT OP CHECK LNs/],
                     rows   => [
-                        ['{json}', '', '{"a":1}', 'JSON', "$hash", '25'],
+                        ['{json}', '', '{"a":1}', 'JSON', "$hash", E],
                         ['{json} <JSON>->{a}', '', '1', 'eq', '2'],
                     ],
                 },


### PR DESCRIPTION
We will explicitly state the `Test2::Compare` checks are available in POD and README. 
This is useful to indicate that the comparison method is not limited to exact matches.

Additionally, append tests and update CPAN libraries.